### PR TITLE
Switch app server from Passenger to Puma

### DIFF
--- a/lib/generators/heroku_installer.rb
+++ b/lib/generators/heroku_installer.rb
@@ -65,7 +65,7 @@ Decidim.seed!
 
       def add_production_gems
         gem_group :production do
-          gem "passenger"
+          gem "puma"
           gem "fog-aws"
           gem "dalli"
           gem "sendgrid-ruby"
@@ -74,10 +74,6 @@ Decidim.seed!
           gem "sentry-raven"
           gem "sidekiq"
         end
-      end
-
-      def remove_puma
-        gsub_file("Gemfile", /^gem 'puma'.*$/, "")
       end
 
       def bundle_install

--- a/lib/generators/templates/procfile.erb
+++ b/lib/generators/templates/procfile.erb
@@ -1,3 +1,3 @@
-web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5}
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml
 release: bundle exec rake db:migrate


### PR DESCRIPTION
Closes #8 

It can deliver better performance and it's Heroku's Rails 5.x default server. See https://devcenter.heroku.com/articles/getting-started-with-rails5#configure-your-webserver.